### PR TITLE
bl-left aligned text and made highlighting not need to end on a word

### DIFF
--- a/script_editor/app/assets/stylesheets/plays.scss
+++ b/script_editor/app/assets/stylesheets/plays.scss
@@ -21,9 +21,9 @@ div.stage {
 
 p.lineNum {
     padding: 0px;
-    margin-right: 10px;
+    margin: 0 10px 0 0;
     font-size: 14px;
-    display: inline;
+    position: absolute;
     color: gray;
     font-family: serif;
 }
@@ -92,6 +92,7 @@ div.script-main {
     bottom: 0;
     right: 15%;
     z-index:0;
+    text-align: left;
 }
 
 #title {
@@ -113,6 +114,8 @@ button:focus {outline:0;}
     margin-left: -5px;
     border:none; 
     font-size: 14px;
+    position: relative;
+    left: 30px;
 }
 
 .word {
@@ -122,6 +125,8 @@ button:focus {outline:0;}
     margin: 0px;
     border:none;
     font-size: 14px;
+    position: relative;
+    left: 30px;
 }
 
 .stage {
@@ -132,6 +137,8 @@ button:focus {outline:0;}
      border:none;
      padding:0!important;
      font-size: 14px;
+     position: relative;
+     left: 30px;
 }
 
 .acthead {

--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -356,7 +356,7 @@
                     function(element) {
                         if (element.className == "word" || element.className == "punc" ||
                             element.className == "stage"){
-                                element.style.backgroundColor = "#0090FF";
+                                element.style.backgroundColor = "#B8D7FB";
                                 if (element.dataset.cut == "false") {
                                     toCut = true
                                 }

--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -321,36 +321,38 @@
 
         down = false
         toCut = false
+        parent = null
         // all words will need to be printed within the div class "script-main"
 
-        function mouseDown(e) {
-            if (e.srcElement.className == "word" || e.srcElement.className == "punc" ||
-                e.srcElement.className == "stage") {
-                    startIndex = lowIndex = highIndex = Array.from(e.srcElement.parentNode.children)
-                                                             .indexOf(e.srcElement)
+        function mouseDown({ srcElement }) {
+            if (srcElement.className == "word" || srcElement.className == "punc" ||
+                srcElement.className == "stage") {
+                    parent = srcElement.parentNode
+                    startIndex = lowIndex = highIndex = Array.from(parent.children)
+                                                             .indexOf(srcElement)
                     down = true
-                    toCut = !(e.srcElement.dataset.cut.to_b)
+                    toCut = !(srcElement.dataset.cut.to_b)
             }
         }
 
-        function mouseOver(e) {
+        function mouseOver({ srcElement }) {
             if (down) {
                 // Clear previous highlighting
-                Array.from(e.srcElement.parentNode.children).slice(lowIndex, highIndex + 1).forEach(
+                Array.from(parent.children).slice(lowIndex, highIndex + 1).forEach(
                     function(element) {
                         element.style.backgroundColor = "#FFFFFF"
                     }
                 )
                 // Update selection
-                if (e.srcElement.className == "word" || e.srcElement.className == "punc" ||
-                    e.srcElement.className == "stage") {
-                        newIndex = Array.from(e.srcElement.parentNode.children).indexOf(e.srcElement)
+                if (srcElement.className == "word" || srcElement.className == "punc" ||
+                    srcElement.className == "stage") {
+                        newIndex = Array.from(parent.children).indexOf(srcElement)
                         lowIndex = newIndex > startIndex ? startIndex : newIndex
                         highIndex = newIndex > startIndex ? newIndex : startIndex
                 }
                 // Highlight and decide on cutting or uncutting
                 toCut = false
-                Array.from(e.srcElement.parentNode.children).slice(lowIndex, highIndex + 1).forEach(
+                Array.from(parent.children).slice(lowIndex, highIndex + 1).forEach(
                     function(element) {
                         if (element.className == "word" || element.className == "punc" ||
                             element.className == "stage"){
@@ -364,18 +366,17 @@
             }
         }
 
-        function mouseUp(e) {
+        function mouseUp({ srcElement }) {
             if (lowIndex == highIndex) {
-                e.srcElement.dataset.cut == "true" ? uncut(e.srcElement) : cut(e.srcElement)
+                srcElement.dataset.cut == "true" ? uncut(srcElement) : cut(srcElement)
             } else {
-                Array.from(e.srcElement.parentNode.children).slice(lowIndex, highIndex + 1).forEach(
+                Array.from(parent.children).slice(lowIndex, highIndex + 1).forEach(
                     function(element){
-                        element.style.backgroundColor = '#FFFFFF'
                         toCut ? cut(element) : uncut(element)
                     }
                 )
             }
-            newIndex = lowIndex = highIndex = startIndex = null
+            newIndex = lowIndex = highIndex = startIndex = parent = null
             down = toCut = false
         }
 
@@ -385,6 +386,7 @@
                     element.style.color = "#D3D3D3"
                     element.style.textDecoration = "line-through"
                     element.dataset.cut = "true"
+                    element.style.backgroundColor = '#FFFFFF'
             }
         }
 
@@ -394,6 +396,7 @@
                     element.style.color = "#000000"
                     element.style.textDecoration = "none"
                     element.dataset.cut = "false"
+                    element.style.backgroundColor = '#FFFFFF'
             }
         }
 


### PR DESCRIPTION
This PR handles small quality of life changes. These include left-aligning the text in a play and making cutting work when the mouse up event occurs on whitespace. It also should prevent text from staying highlighted when it shouldn't be anymore.

@MontanaRoberts @hmc-cs-jcrewe @hmc-cs-celliott 