### PR TITLE
Bl analytics with tags

### DIFF
--- a/script_editor/app/assets/stylesheets/plays.scss
+++ b/script_editor/app/assets/stylesheets/plays.scss
@@ -175,6 +175,24 @@ button:focus {outline:0;}
      padding:0!important;
 }
 
+p.analytic {
+   margin-top: 0px;
+   margin-bottom: 0px;
+}
+
+span.original {
+    width: 50%;
+    float: left;
+}
+
+span.concise {
+    width: 50%;
+    text-align: right;
+}
+
+.concise {
+}
+
 /////////////////////////////////
 // For the navigation bar
 /////////////////////////////////

--- a/script_editor/app/assets/stylesheets/plays.scss
+++ b/script_editor/app/assets/stylesheets/plays.scss
@@ -190,9 +190,6 @@ span.concise {
     text-align: right;
 }
 
-.concise {
-}
-
 /////////////////////////////////
 // For the navigation bar
 /////////////////////////////////

--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -215,15 +215,6 @@
         <div class="modal-content">
             <span class="close2">&times;</span>
             <div class="hidden-analytics" id="hidden-analytics"></div>
-            <!--
-            <% analyticstext = "Total Lines: ????" %>
-            <script>
-                document.getElementById('hidden-analytics').innerHTML = '<%= escape_javascript analyticstext %>';
-            </script>
-            -->
-            <script>
-                
-            </script>
         </div>
     </div>
 

--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -2,11 +2,11 @@
 <html><body>
     <p id="notice"></p>
 
-    <!-- 
-        Decide what XML file to open depending on the URL.
-        We did them one-by-one because the URL's didn't match
-        Folger Digital Text's file-naming scheme. 
-    -->
+    <%
+        #Decide what XML file to open depending on the URL.
+        #We did them one-by-one because the URL's didn't match
+        #Folger Digital Text's file-naming scheme. 
+    %>
     <% doc = Nokogiri::XML(File.open("FolgerDigitalTexts_XML_Complete/MND.xml"))
     if "#{request.fullpath}" == "/plays/a_midsummer_nights_dream"
         doc = Nokogiri::XML(File.open("FolgerDigitalTexts_XML_Complete/MND.xml"))
@@ -95,9 +95,9 @@
     end %>
 
 
-    <!-- 
-        Get title of play and display at top of page 
-    -->
+    <% 
+        # Get title of play and display at top of page 
+    %>
     <div class="script-title">
         <div id="Home-button">
             <a id="home" href="/">Home</a>
@@ -112,10 +112,10 @@
     </div>
 
 
-    <!-- 
-        Parse the XML file for number of acts & scenes in order to 
-        create the navigation bar 
-    -->
+    <% 
+        #Parse the XML file for number of acts & scenes in order to 
+        #create the navigation bar 
+    %>
     <div class="script-side-bar">
         <div class="play-navigation">
 
@@ -167,7 +167,7 @@
              </script>
              <div class = "break"> </div>
 
-            <!-- Create a button for each act and scene in the play -->
+            <% # Create a button for each act and scene in the play %>
             <% currAct = 1 %>
             <% currScene = 1 %>
             <% currIndex = 1 %>
@@ -219,9 +219,9 @@
     </div>
 
 
-    <!-- 
-        Parse the XML file for the actual script, and display everything 
-    -->
+    <% 
+        #Parse the XML file for the actual script, and display everything 
+    %>
     <div class="script-main"> 
         <% currAct = 1 %>
         <% currScene = 1 %>
@@ -261,17 +261,18 @@
                 <% lines = Nokogiri::XML(scene.to_s).css('//sp') %>
                 <% stages = Nokogiri::XML(scene.to_s).css('stage').to_a %>
 
+
                 <% lines.each do |line| %>
-                <!-- DISPLAY STAGE DIRECTIONS -->
-                    <!-- Get line id -->
+                    <% #DISPLAY STAGE DIRECTIONS %>
+                    <% #Get line id %>
                     <% lineN = line.attr("xml:id").to_s.gsub("sp-","").to_f %>
 
                     <% stages.each do |stage| %>
-                        <!-- Get stage direction id -->
+                        <% #Get stage direction id %>
                         <% stageN = stage.attr('xml:id').to_s.gsub("stg-","").to_f %>
-                        <!-- If there is a stage dir that comes before the line -->
+                        <% #If there is a stage dir that comes before the line %>
                         <% if (stageN < lineN) and (stageN >= lineN-1.0)%>
-                            <!-- display stage direction -->
+                            <% #display stage direction %>
                             <br>
                             <button class="stage" data-cut="false" data-display="true">
                                 <%= stage.inner_text %>
@@ -281,27 +282,27 @@
                         <% end %>
                     <% end %>
 
-                    <!-- Getting all the info needed for each line -->
+                    <% # getting all the info needed for each line %>
                     <% speaker = Nokogiri::XML(line.to_s).css('speaker') %>
                     <% milestones = Nokogiri::XML(line.to_s).css('milestone') %>
                     <% spwords = Nokogiri::XML(line.to_s).css('w','c','pc') %>
 
-                    <!-- DISPLAY SPEAKER -->
+                    <% # DISPLAY SPEAKER %>
                     <br>
                     <p class="speaker">
                         <%=speaker.inner_text%>
                     </p>
                     <br>
-                    <!-- DISPLAY LINES -->
+                    <% # DISPLAY LINES %>
                     <% milestones.each do |ms| %>
 
                         <% msN = ms.attr("xml:id").to_s.gsub("ftln-","").to_f %>
                         <% stages.each do |stage| %>
-                            <!-- Get stage direction id -->
+                            <% # Get stage direction id %>
                             <% stageN = stage.attr('xml:id').to_s.gsub("stg-","").to_f %>
-                            <!-- If there is a stage dir inside speech -->
+                            <% # If there is a stage dir inside speech %>
                             <% if (stageN <= msN) and (stageN >= msN-1.0) %>
-                            <!-- display stage direction -->
+                            <% # display stage direction %>
                                 <button class="stage" data-cut="false" data-display="true">
                                     <%= stage.inner_text %>
                                 </button>
@@ -310,15 +311,15 @@
                             <% end %>
                         <% end %>
 
-                        <!-- get line number -->
+                        <% # get line number %>
                         <% lineNum = ms.attr("n").to_s.split(".")[2] %>
-                        <!-- get corresps per milestone in array -->
+                        <% # get corresps per milestone in array %>
                         <% wordIDs = ms.attr("corresp").to_s.split(" ") %>
-                        <!-- remove #s -->
+                        <% # remove #s %>
                         <% wordIDs = wordIDs.map { |w| w.gsub("#","")} %>
-                        <!-- Search spwords for corresponding w/c/pc -->
+                        <% # Search spwords for corresponding w/c/pc %>
                         
-                        <!-- DISPLAY LINE NUMBER -->
+                        <% # DISPLAY LINE NUMBER %>
                         <% if lineNum.to_i % 5 == 0 %>
                             <p class="lineNum">
                                 <%= lineNum %>
@@ -328,43 +329,49 @@
                         <% wordIDs.each do |id| %>
                             <% spwords.each do |word| %>
                                 <% if word.attr('xml:id').to_s == id %>
-                                    <!-- DISPLAY EACH WORD -->
+                                    <% # DISPLAY EACH WORD %>
                                     <% if (word.inner_text == ".") || (word.inner_text == ",") || (word.inner_text == "?") || (word.inner_text == "!") || (word.inner_text == ";") || (word.inner_text == ":") %>
                                         <button class="punc" data-cut="false" data-display="true" data-lineNum=<%= lineNum %>>
                                             <%= word.inner_text %>
                                         </button>
-                                <% else %>
-                                    <% if word.inner_text != "" && word.inner_text != " " %>
-                                        <button class="word" data-cut="false" data-display="true" data-lineNum=<%= lineNum %>>
-                                            <%= word.inner_text %>
-                                        </button>
+                                    <% else %>
+                                        <% if word.inner_text != "" && word.inner_text != " " %>
+                                            <button class="word" data-cut="false" data-display="true" data-lineNum=<%= lineNum %>>
+                                                <%= word.inner_text %>
+                                            </button>
+                                        <% end %>
                                     <% end %>
                                 <% end %>
                             <% end %>
                         <% end %>
-                    <% end %>
 
-                    <!-- BREAK FOR NEW LINE -->
-                    <br>
+                        <% # BREAK FOR NEW LINE %>
+                        <br>
 
 
-                    <% stages.each do |stage| %>
-                        <!-- Get stage direction id -->
-                        <% stageN = stage.attr('xml:id').to_s.gsub("stg-","").to_f %>
-                        <!-- If there is a stage dir inside speech -->
-                        <% if (stageN >= msN) and (stageN < msN+1.0) %>
-                            <!-- display stage direction -->
-                            <button class="stage" data-cut="false" data-display="true"> <%= stage.inner_text %> </button> <br>
-                            <% stages.delete(stage) %>
+                        <% stages.each do |stage| %>
+                            <% # Get stage direction id %>
+                            <% stageN = stage.attr('xml:id').to_s.gsub("stg-","").to_f %>
+                            <% # If there is a stage dir inside speech %>
+                            <% if (stageN >= msN) and (stageN < msN+1.0) %>
+                                <% # display stage direction %>
+                                <button class="stage" data-cut="false" data-display="true">
+                                    <%= stage.inner_text %>
+                                </button>
+                                <br>
+                                <% stages.delete(stage) %>
+                            <% end %>
                         <% end %>
-                    <% end %>
 
-                <% end %>
+                    <% end %>
                 <% end %>
                 
                 <br>
                 <% stages.each do |stage| %>
-                    <button class="stage" data-cut="false" data-display="true"><%= stage.inner_text %></button> <br>
+                    <button class="stage" data-cut="false" data-display="true">
+                        <%= stage.inner_text %>
+                    </button>
+                    <br>
                     <% stages.delete(stage) %>
                 <% end %>
             <% end%>
@@ -658,7 +665,7 @@
         }
 
         getScenes = function (script) {
-            actsAndScenes = new Set([script.children[0]]);
+            actsAndScenes = new Set(Array.from(script.getElementsByClassName('actDiv')));
             scenes = new Set();
             // begin searching
             let searching = true;

--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -215,9 +215,14 @@
         <div class="modal-content">
             <span class="close2">&times;</span>
             <div class="hidden-analytics" id="hidden-analytics"></div>
+            <!--
             <% analyticstext = "Total Lines: ????" %>
             <script>
                 document.getElementById('hidden-analytics').innerHTML = '<%= escape_javascript analyticstext %>';
+            </script>
+            -->
+            <script>
+                
             </script>
         </div>
     </div>
@@ -234,7 +239,11 @@
         <% acts= doc.css('//div1') %>
         <% acts.each do |act| %>
             <% if Nokogiri::XML(act.to_s).css('head').first != nil %>
-            <div class="actDiv" id="Diva"><button class="acthead" id="current-act" data-cut="false" data-display="true"> <%= Nokogiri::XML(act.to_s).css('head').first.inner_text %></button><br></b>
+            <div class="actDiv" id="Diva">
+                <button class="acthead" id="current-act" data-cut="false" data-display="true">
+                    <%= Nokogiri::XML(act.to_s).css('head').first.inner_text %>
+                </button>
+                <br/>
             <% end %>
             <script>
                 document.getElementById('current-act').id = '<%= escape_javascript "a" + currAct.to_s %>';
@@ -245,7 +254,11 @@
             <% currScene = 1 %>
             <% scenes.each do |scene| %>
                 <% if Nokogiri::XML(scene.to_s).css('head').first != nil %>
-                <div class="sceneDiv" id="Divs"><button class="scenehead" id="current-scene" data-cut="false" data-display="true"><%= Nokogiri::XML(scene.to_s).css('head').first.inner_text %></button><br>
+                    <div class="sceneDiv" id="Divs">
+                        <button class="scenehead" id="current-scene" data-cut="false" data-display="true">
+                            <%= Nokogiri::XML(scene.to_s).css('head').first.inner_text %>
+                        </button>
+                        <br>
                 <% end %>
                 <script>
                     document.getElementById('current-scene').id = '<%= escape_javascript "s" + currIndex.to_s %>';
@@ -269,7 +282,10 @@
                         <% if (stageN < lineN) and (stageN >= lineN-1.0)%>
                             <!-- display stage direction -->
                             <br>
-                            <button class="stage" data-cut="false" data-display="true"> <%= stage.inner_text %> </button> <br>
+                            <button class="stage" data-cut="false" data-display="true">
+                                <%= stage.inner_text %>
+                            </button>
+                            <br>
                             <% stages.delete(stage) %>
                         <% end %>
                     <% end %>
@@ -280,8 +296,11 @@
                     <% spwords = Nokogiri::XML(line.to_s).css('w','c','pc') %>
 
                     <!-- DISPLAY SPEAKER -->
-                    <br><p class="speaker"><%=speaker.inner_text%> </p><br>
-
+                    <br>
+                    <p class="speaker">
+                        <%=speaker.inner_text%>
+                    </p>
+                    <br>
                     <!-- DISPLAY LINES -->
                     <% milestones.each do |ms| %>
 
@@ -292,7 +311,10 @@
                             <!-- If there is a stage dir inside speech -->
                             <% if (stageN <= msN) and (stageN >= msN-1.0) %>
                             <!-- display stage direction -->
-                                <button class="stage" data-cut="false" data-display="true"> <%= stage.inner_text %> </button> <br>
+                                <button class="stage" data-cut="false" data-display="true">
+                                    <%= stage.inner_text %>
+                                </button>
+                                <br>
                                 <% stages.delete(stage) %>
                             <% end %>
                         <% end %>
@@ -307,18 +329,24 @@
                         
                         <!-- DISPLAY LINE NUMBER -->
                         <% if lineNum.to_i % 5 == 0 %>
-                            <p class="lineNum"><%= lineNum %></p>
+                            <p class="lineNum">
+                                <%= lineNum %>
+                            </p>
                         <% end %>
 
                         <% wordIDs.each do |id| %>
                             <% spwords.each do |word| %>
                                 <% if word.attr('xml:id').to_s == id %>
-                                <!-- DISPLAY EACH WORD -->
-                                <% if (word.inner_text == ".") || (word.inner_text == ",") || (word.inner_text == "?") || (word.inner_text == "!") || (word.inner_text == ";") || (word.inner_text == ":") %>
-                                    <button class="punc" data-cut="false" data-display="true"><%= word.inner_text %></button>
+                                    <!-- DISPLAY EACH WORD -->
+                                    <% if (word.inner_text == ".") || (word.inner_text == ",") || (word.inner_text == "?") || (word.inner_text == "!") || (word.inner_text == ";") || (word.inner_text == ":") %>
+                                        <button class="punc" data-cut="false" data-display="true" data-lineNum=<%= lineNum %>>
+                                            <%= word.inner_text %>
+                                        </button>
                                 <% else %>
                                     <% if word.inner_text != "" && word.inner_text != " " %>
-                                        <button class="word" data-cut="false" data-display="true"><%= word.inner_text %></button>
+                                        <button class="word" data-cut="false" data-display="true" data-lineNum=<%= lineNum %>>
+                                            <%= word.inner_text %>
+                                        </button>
                                     <% end %>
                                 <% end %>
                             <% end %>
@@ -601,6 +629,16 @@
         span.onclick = function() {
             modal.style.display = "none";
         }
+
+        // From MDN
+        union = function(setA, setB) {
+            var union = new Set(setA);
+            for (var elem of setB) {
+                union.add(elem);
+            }
+            return union;
+        }
+
         /** 
          * This controls the analytics button in the navigation bar.
          */
@@ -609,7 +647,80 @@
         var span2 = document.getElementsByClassName("close2")[0];
         btn2.onclick = function() {
             modal2.style.display = "block";
+            script = document.querySelector(".script-main");
+            scenes = getScenes(script);
+            analytics = countAnalytics(scenes);
+            innerHTML = `<p class="analytic"><span class="original">Original</span><span class="concise">Concise</span></p><pclass="analytic"><span class="original">Lines: ${analytics.lines.size}</span><span class="concise">Concise Lines: ${analytics.uncutLines.size}</span></p>`
+            for (character in characterLines) {
+                innerHTML += `<pclass="analytic"><span class="original">${character}: ${characterLines[character].total.size}</span><span class="concise">${character}: ${characterLines[character].uncut.size}</span></p>`
+            }
+            document.getElementById('hidden-analytics').innerHTML = innerHTML;
         }
+
+        getScenes = function (script) {
+            acts = new Set([script.children[0]]);
+            scenes = new Set();
+
+            let searching = true;
+            while(searching) {
+                searching = false;
+                union(acts, scenes).forEach(
+                    function(actOrScene) {
+                        Array.from(actOrScene.children).forEach(
+                            function(child) {
+                                if (child.className == 'actDiv') {
+                                    if (!acts.has(child)) {
+                                        acts.add(child)
+                                        searching = true
+                                    }
+                                }
+                                if (child.className == 'sceneDiv') {
+                                    if (!scenes.has(child)) {
+                                        scenes.add(child)
+                                        searching = true
+                                    }
+                                }
+                            }
+                        )
+                    }
+                )
+            }
+            return scenes
+        }
+
+        countAnalytics = function (scenes) {
+            lines = new Set()
+            uncutLines = new Set()
+            characterLines = {}
+            curChar = null
+            lineOffset = lineNum = 0
+            scenes.forEach(
+                function(scene){
+                    lineOffset += lineNum
+                    Array.from(scene.children).forEach(
+                        function(child) {
+                            if (child.className == 'speaker') {
+                                curChar = child.innerText
+                            }
+                            if (child.dataset.linenum) {
+                                lineNum = parseInt(child.dataset.linenum)
+                                lines.add(lineOffset + lineNum)
+                                if (!(Object.keys(characterLines).includes(curChar))) {
+                                    characterLines[curChar] = { total: new Set(), uncut: new Set() }
+                                }
+                                characterLines[curChar].total.add(lineOffset + lineNum)
+                                if (child.dataset.cut == "false") {
+                                    uncutLines.add(lineOffset + lineNum)
+                                    characterLines[curChar].uncut.add(lineOffset + lineNum)
+                                }
+                            }
+                        }
+                    )
+                }
+            )
+            return { lines: lines, uncutLines: uncutLines, characterLines: characterLines }
+        }
+
         span2.onclick = function() {
             modal2.style.display = "none";
         }

--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -630,7 +630,8 @@
             modal.style.display = "none";
         }
 
-        // From MDN
+        // Modified from MDN for set unions
+        // This isn't used after optimization, but could be useful later
         union = function(setA, setB) {
             var union = new Set(setA);
             for (var elem of setB) {
@@ -650,40 +651,56 @@
             script = document.querySelector(".script-main");
             scenes = getScenes(script);
             analytics = countAnalytics(scenes);
-            innerHTML = `<p class="analytic"><span class="original">Original</span><span class="concise">Concise</span></p><pclass="analytic"><span class="original">Lines: ${analytics.lines.size}</span><span class="concise">Concise Lines: ${analytics.uncutLines.size}</span></p>`
-            for (character in characterLines) {
-                innerHTML += `<pclass="analytic"><span class="original">${character}: ${characterLines[character].total.size}</span><span class="concise">${character}: ${characterLines[character].uncut.size}</span></p>`
+            formatAnalytics(analytics);
+        }
+
+        formatAnalytics = function(analytics) {
+            // setup
+            innerHTML = `<p class="analytic"><span class="original">Original</span><span class="concise">Concise</span></p>`;
+            // total lines
+            innerHTML += `<p class="analytic"><span class="original">Lines: ${analytics.lines.size}</span><span class="concise">Concise Lines: ${analytics.uncutLines.size}</span></p>`
+            // character lines
+            for (character in analytics.characterLines) {
+                innerHTML += `<p class="analytic"><span class="original">${character}: ${characterLines[character].total.size}</span><span class="concise">${character}: ${characterLines[character].uncut.size}</span></p>`
             }
             document.getElementById('hidden-analytics').innerHTML = innerHTML;
         }
 
         getScenes = function (script) {
-            acts = new Set([script.children[0]]);
+            actsAndScenes = new Set([script.children[0]]);
             scenes = new Set();
-
+            // begin searching
             let searching = true;
             while(searching) {
                 searching = false;
-                union(acts, scenes).forEach(
+                // Prevents researching
+                newSet = new Set(Array.from(actsAndScenes.values()));
+                actsAndScenes.forEach(
                     function(actOrScene) {
                         Array.from(actOrScene.children).forEach(
                             function(child) {
                                 if (child.className == 'actDiv') {
-                                    if (!acts.has(child)) {
-                                        acts.add(child)
+                                    // these ifs are for searching, not the sets
+                                    if (!actsAndScenes.has(child)) {
+                                        newSet.add(child)
                                         searching = true
                                     }
                                 }
                                 if (child.className == 'sceneDiv') {
+                                    // these ifs are for searching, not the sets
                                     if (!scenes.has(child)) {
+                                        newSet.add(child)
                                         scenes.add(child)
                                         searching = true
                                     }
                                 }
                             }
                         )
+                        // avoid researching
+                        newSet.delete(actOrScene)
                     }
                 )
+                actsAndScenes = newSet
             }
             return scenes
         }


### PR DESCRIPTION
This PR covers a bit of code reformatting in the form of fixing the indentation for the play parsing so that it actually makes sense. The rest of the changes in this PR involve adding tags to every word with a line number that contains that number, and a method to use these tags to calculate analytics. The analytics are calculated whenever the analytics button is pushed, and currently not saved anywhere but the html.

The analytics work by using sets to avoid saving unnecessary duplicate information. We first gather the scenes by searching through the html so that we don't have to deal with the formatting, and then we search these scenes for each line that appears, storing them in sets. Then we count the size of those sets.

@hmc-cs-jcrewe @MontanaRoberts @hmc-cs-celliott 