### PR TITLE
Bl analytics speaker cuts bug

### DIFF
--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -845,7 +845,6 @@
                         function(child) {
                             if (child.className == 'speaker') {
                                 curChar = child.innerText.trim()
-                                console.log(curChar)
                             }
                             if (child.dataset.linenum) {
                                 lineNum = parseInt(child.dataset.linenum)

--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -844,7 +844,8 @@
                     Array.from(scene.children).forEach(
                         function(child) {
                             if (child.className == 'speaker') {
-                                curChar = child.innerText
+                                curChar = child.innerText.trim()
+                                console.log(curChar)
                             }
                             if (child.dataset.linenum) {
                                 lineNum = parseInt(child.dataset.linenum)


### PR DESCRIPTION
@hmc-cs-jcrewe reported a bug that caused speakers to be duplicated when the speaker is cut and edits were hidden. This was caused by the cutting action adding whitespace around the name for some reason. Trimming the name removes this whitespace and makes it work as intended.

@MontanaRoberts @hmc-cs-celliott @hmc-cs-jcrewe 