### PR TITLE
Disable ability to edit while in concise mode

### DIFF
--- a/script_editor/app/assets/stylesheets/plays.scss
+++ b/script_editor/app/assets/stylesheets/plays.scss
@@ -144,6 +144,9 @@ button:focus {outline:0;}
     left: 30px;
 }
 
+button:disabled {
+    color: black
+}
 .stage {
      background:none;
      background-color: none;

--- a/script_editor/app/views/plays/show.html.erb
+++ b/script_editor/app/views/plays/show.html.erb
@@ -151,13 +151,18 @@
                     var speakers = Array.from(document.getElementsByClassName("speaker"))
                     var cuttableScript = words.concat(punctuation).concat(directions).concat(speakers);
                     cuttableScript.forEach(function(word) {
-                        if (toggleBtn.curState == "showing" && word.dataset.cut == "true") // User wishes to hide edit
+                        if (toggleBtn.curState == "showing" ) // User wishes to hide edit
                         {
+                            word.disabled = 'true'
+                            if (word.dataset.cut == "true")
+                            { 
                             word.style.display = 'none'
+                            }
                         }
-                        else //user wishes to show edits
+                        else //User wishes to show edits
                         {
                             word.style.display = 'initial'
+                            word.removeAttribute('disabled')
                         }
 
                     })


### PR DESCRIPTION
This pull request disables the ability to edit the play through highlighting while in concise mode. I'm still working on disabling speaker cuts while in concise mode. 